### PR TITLE
allow responsive viewport size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "concurrent-browser-mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "concurrent-browser-mcp",
-      "version": "1.4.0",
-      "license": "MIT",
+      "version": "1.5.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.6.0",
         "chalk": "^5.3.0",

--- a/src/browser-manager.ts
+++ b/src/browser-manager.ts
@@ -213,6 +213,7 @@ export class BrowserManager {
           browserType: config.browserType,
           headless: config.headless,
           viewport: config.viewport,
+          responsive: config.viewport === null,
           proxy: effectiveProxy,
           metadata
         },

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -40,7 +40,12 @@ export class BrowserTools {
                 width: { type: 'number', default: 1280 },
                 height: { type: 'number', default: 720 }
               },
-              description: 'Viewport size'
+              description: 'Viewport size (ignored if responsive is true)'
+            },
+            responsive: {
+              type: 'boolean',
+              description: 'Enable responsive mode with no fixed viewport (passes null to Playwright)',
+              default: false
             },
             userAgent: {
               type: 'string',
@@ -500,7 +505,8 @@ export class BrowserTools {
             {
               browserType: args.browserType || 'chromium',
               headless: args.headless ?? true,
-              viewport: args.viewport || { width: 1280, height: 720 },
+              viewport: args.responsive ? null : (args.viewport || { width: 1280, height: 720 }),
+              responsive: args.responsive ?? false,
               userAgent: args.userAgent
             },
             args.metadata

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,8 @@ export interface BrowserConfig {
   viewport?: {
     width: number;
     height: number;
-  };
+  } | null;
+  responsive?: boolean;
   userAgent?: string;
   proxy?: ProxyConfig;
   contextOptions?: {


### PR DESCRIPTION
## Add Responsive Viewport Mode

### Summary
Adds a `responsive` parameter to `browser_create_instance` that passes `null` viewport to Playwright, enabling freely resizable browser windows for responsive layout testing.

### Problem
The upstream MCP hardcodes viewport to `{width: 1280, height: 720}`, preventing:
- Testing responsive layouts
- Resizing browser windows freely
- Matching real user viewport conditions

### Solution
When `responsive: true` is passed, viewport is set to `null` in Playwright.

### Changes
| File | Change |
|------|--------|
| `src/types.ts` | `viewport` accepts `null`, added `responsive?: boolean` |
| `src/tools.ts` | Added `responsive` param to schema, passes `null` when enabled |
| `src/browser-manager.ts` | Returns `responsive: true` in response data |

### Usage
```typescript
// Responsive mode - window freely resizable
browser_create_instance({ headless: false, responsive: true })
// Returns: { viewport: null, responsive: true, ... }

// Fixed mode (default) - 1280x720
browser_create_instance({ headless: false })
// Returns: { viewport: { width: 1280, height: 720 }, ... }
```